### PR TITLE
Updated db connect hooks to allow extDB2 Logging

### DIFF
--- a/@ExileServer/addons/AVS/config.cpp
+++ b/@ExileServer/addons/AVS/config.cpp
@@ -16,7 +16,7 @@ class CfgPatches
 	{
 		units[] = {};
 		weapons[] = {};
-		AVS_Version = "1.4.3";
+		AVS_Version = "1.4.4";
 	};
 };
 
@@ -42,7 +42,7 @@ class CfgFunctions
 			class loadAmmo						{};
 			class rearmVehicle					{};
 			class refuelPayment					{};
-			class refuelVehicle					{};		
+			class refuelVehicle					{};
 			class sanitizeVehicle				{};
 			class saveAmmo						{};
 			class spawnAllVehicles				{};

--- a/@ExileServer/addons/AVS/hooks/AVS_system_database_connect.sqf
+++ b/@ExileServer/addons/AVS/hooks/AVS_system_database_connect.sqf
@@ -1,39 +1,86 @@
-/*
-© 2015 Zenix Gaming Ops
-Developed by Rod-Serling
-Co-Developed by Vishpala
+/**
+ * ExileServer_system_database_connect
+ *
+ * Exile Mod
+ * www.exilemod.com
+ * Â© 2015 Exile Mod Team
+ *
+ * This work is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
+ * To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/.
 
-All rights reserved.
+ ï¿½ 2015 Zenix Gaming Ops
+ Developed by Rod-Serling
+ Co-Developed by Vishpala
+ Updated to 1.0.0 by Edisubaru
 
-Function:
-	AVS_system_database_connect hook - Redirects Exile function calls to perform AVS functions.
-*/
+ All rights reserved.
+
+ Function:
+ 	AVS_system_database_connect hook - Redirects Exile function calls to perform AVS functions.
+
+ */
+
+private["_isConnected","_error","_result"];
 _isConnected = false;
+_error_locked = false;
+ExileServerDatabaseSessionId = "";
+ExileServerRconSessionID = "";
 try
 {
+	_result = "extDB2" callExtension "9:VERSION";
+	if (_result isEqualTo "") then
+	{
+		throw "Unable to locate extDB2 extension!";
+	};
+	if (parseNumber _result < 69) then
+	{
+		throw "Update extDB2 to version 69 or later";
+	};
+	format ["Installed extDB2 version: %1", _result] call ExileServer_util_log;
+	_result = call compile ("extDB2" callExtension "9:LOCK_STATUS") select 0;
+	if (_result isEqualTo 1) then
+	{
+		_error_locked = true;
+		throw "Error extDB2 is already setup & locked !!!";
+	};
 	_result = call compile ("extDB2" callExtension "9:ADD_DATABASE:exile");
-
 	if (_result select 0 isEqualTo 0) then
 	{
 		throw format ["Could not add database: %1", _result];
 	};
-	diag_log "AVS - Connected to database!";
+	"Connected to database!" call ExileServer_util_log;
+  diag_log "AVS - Connected to database!";
 	ExileServerDatabaseSessionId = str(round(random(999999)));
 	_result = call compile ("extDB2" callExtension format["9:ADD_DATABASE_PROTOCOL:exile:SQL_CUSTOM_V2:%1:exile", ExileServerDatabaseSessionId]);
-	_result = call compile ("extDB2" callExtension "9:ADD_DATABASE_PROTOCOL:exile:SQL_CUSTOM_V2:AVSDB:avs");
-
+  _result = call compile ("extDB2" callExtension "9:ADD_DATABASE_PROTOCOL:exile:SQL_CUSTOM_V2:AVSDB:avs");
 	if ((_result select 0) isEqualTo 0) then
 	{
 		throw format ["Failed to initialize database protocol: %1", _result];
 	};
-	ExileServerStartTime = (call compile ("extDB2" callExtension "9:TIME")) select 1;
+	ExileServerStartTime = (call compile ("extDB2" callExtension "9:LOCAL_TIME")) select 1;
+	"Database protocol initialized!" call ExileServer_util_log;
+	"extDB2" callExtension "9:ADD_PROTOCOL:LOG:TRADING:Exile_TradingLog";
+	"extDB2" callExtension "9:ADD_PROTOCOL:LOG:DEATH:Exile_DeathLog";
+	"extDB2" callExtension "9:ADD_PROTOCOL:LOG:TERRITORY:Exile_TerritoryLog";
 	"extDB2" callExtension "9:LOCK";
 	_isConnected = true;
 }
 catch
 {
-	diag_log "AVS - Database connection error!";
-	diag_log format ["AVS - Database Error: %1", _exception];
-	"extDB2" callExtension "9:SHUTDOWN";
+	if (!_error_locked) then
+	{
+		"MySQL connection error!" call ExileServer_util_log;
+		"Please have a look at @ExileServer/extDB/logs/ to find out what went wrong." call ExileServer_util_log;
+		format ["MySQL Error: %1", _exception]  call ExileServer_util_log;
+		"Server will shutdown now :(" call ExileServer_util_log;
+		"extDB2" callExtension "9:SHUTDOWN";
+	}
+	else
+	{
+		format ["extDB2: %1", _exception] call ExileServer_util_log;
+    diag_log "AVS - Database connection error!";
+  	diag_log format ["AVS - Database Error: %1", _exception];
+		"Check your server rpt for errors, your mission might be stuck a loop restarting" call ExileServer_util_log;
+	};
 };
 _isConnected


### PR DESCRIPTION
Simply updated this hooks (which is actually not an hooks but an overwrite an it's the problem) to exile 1.0.0 (don't know if it's different on 1.0.1 but I don't think so) to enable the new logging included in Exile and the use of localtime instead time for server lock.

PS: My text editor is strange about whitespaces / tabs but no worry ^^

Edit : it's the same for 1.0.1.